### PR TITLE
Statement.php: invalid return if default is reached

### DIFF
--- a/src/sparqlClient/Statement.php
+++ b/src/sparqlClient/Statement.php
@@ -67,9 +67,8 @@ class Statement implements \Iterator {
                     return $row[array_keys($row)[0]];
                 default;
             }
-        } else {
-            return false;
         }
+        return false;
     }
 
     public function fetchColumn(): object | false {


### PR DESCRIPTION
If in `fetch` method `default` is reached, it results in `none` returned. But that violates given return types (`object`, `array`, `false`).